### PR TITLE
Update Adafruit_SSD1306.h

### DIFF
--- a/src/Adafruit_SSD1306.h
+++ b/src/Adafruit_SSD1306.h
@@ -38,10 +38,17 @@
 
 #if defined(PARTICLE)
 #include "Particle.h"
+#ifndef SPI_HAS_TRANSACTION
 #define SPI_HAS_TRANSACTION
+#endif
+
 #define SPISettings __SPISettings
 #define BUFFER_LENGTH 32
+
+#ifndef SPI_HAS_TRANSACTION
 #define SPI_HAS_TRANSACTION 1
+#endif
+
 #else
 #include <Wire.h>
 #include <SPI.h>


### PR DESCRIPTION
Overview

This pull request addresses the warning messages about SPI_HAS_TRANSACTION redefinition in the Adafruit_SSD1306 library when compiling for Particle devices.

Details

The warning was due to the SPI_HAS_TRANSACTION flag being defined twice in the Adafruit_SSD1306 library code when the PARTICLE macro is defined. This pull request modifies the code to first check if SPI_HAS_TRANSACTION is already defined before defining it, which should remove the warnings.

The changes include:

Check if SPI_HAS_TRANSACTION is already defined before defining it in the Particle-specific section of the library code.